### PR TITLE
Added WarmWhite and CoolWhite support

### DIFF
--- a/Bulb.js
+++ b/Bulb.js
@@ -85,6 +85,20 @@ class Bulb extends events.EventEmitter {
             this.color = { r, g, b };
         });
     }
+    
+    setWarmWhite(w) {
+        if (!this._socket)
+            return;
+
+        this._writeBytes([ 0x31, 0,0,0, w, 0x0f, 0x0f ]);
+        this._getResponse(1, response => {
+            this.mode = "warmWhite";
+        });
+    }
+
+    setCoolWhite(w) {
+        this.setRgb(w, w, w);
+    }
 
     _handleSocketConnect() {
         this.emit('connected');

--- a/Bulb.js
+++ b/Bulb.js
@@ -90,7 +90,7 @@ class Bulb extends events.EventEmitter {
         if (!this._socket)
             return;
 
-        this._writeBytes([ 0x31, 0,0,0, w, 0x0f, 0x0f ]);
+        this._writeBytes([ 0x31, 0, 0, 0, w, 0x0f, 0x0f ]);
         this._getResponse(1, response => {
             this.mode = "warmWhite";
         });


### PR DESCRIPTION
Looked up the protocol in the comments of the python flux_led library, added setWarmWhite() based on the data for the 8-byte protocol of bulbs that cannot set both RGB and W at once.  It appears that (for my bulbs at least) "cool white" is RGB white, so I added setCoolWhite() which just maps to setRgb()

Thanks for making this library.